### PR TITLE
Add entry routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3699,10 +3699,11 @@
 		},
 		"packages/core": {
 			"name": "crelte",
-			"version": "0.3.0",
+			"version": "0.3.1",
 			"dependencies": {
 				"crelte-std": "^0.1.1",
-				"svelte": "^4.2.12"
+				"svelte": "^4.2.12",
+				"trouter": "^4.0.0"
 			},
 			"devDependencies": {
 				"@sveltejs/package": "^2.3.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,14 +71,15 @@
 	},
 	"dependencies": {
 		"crelte-std": "^0.1.1",
-		"svelte": "^4.2.12"
+		"svelte": "^4.2.12",
+		"trouter": "^4.0.0"
 	},
 	"devDependencies": {
 		"@sveltejs/package": "^2.3.1",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",
 		"svelte-check": "^4.1.4",
 		"typescript-svelte-plugin": "^0.3.45",
-		"vitest": "^2.0.0",
-		"vite": "^5.0"
+		"vite": "^5.0",
+		"vitest": "^2.0.0"
 	}
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,12 @@ export {
 	type LoadDataArray,
 };
 
+export type Entry = {
+	sectionHandle: string;
+	typeHandle: string;
+	[key: string]: any;
+};
+
 /**
  * Get Crelte from the current context
  *

--- a/packages/core/src/init/shared.ts
+++ b/packages/core/src/init/shared.ts
@@ -178,7 +178,8 @@ async function queryEntry<E, T>(
 	if (typeof app.entryRoutes === 'function') {
 		const entryRouter = new EntryRouter();
 		// the user might have a entryRoute which matches
-		await app.entryRoutes(entryRouter);
+		// todo this should only be called once, not on every request
+		await app.entryRoutes(cr, entryRouter);
 
 		const entry = await entryRouter._handle(cr);
 		if (entry) return entry;

--- a/packages/core/src/routing/EntryRouter.ts
+++ b/packages/core/src/routing/EntryRouter.ts
@@ -1,0 +1,41 @@
+import { Pattern, Trouter } from 'trouter';
+import { CrelteRequest, Entry } from '../index.js';
+
+export type EntryRouteHandler = (
+	cr: CrelteRequest,
+) => Promise<Entry | null | undefined> | Entry | null | undefined;
+
+export type EntryRoutes = (router: EntryRouter) => Promise<void> | void;
+
+export default class EntryRouter {
+	private inner: Trouter<EntryRouteHandler>;
+
+	constructor() {
+		this.inner = new Trouter();
+	}
+
+	add(pattern: Pattern, ...handlers: EntryRouteHandler[]): this {
+		this.inner.add('GET', pattern, ...handlers);
+		return this;
+	}
+
+	/** @hidden */
+	async _handle(cr: CrelteRequest): Promise<Entry | null> {
+		const { params, handlers } = this.inner.find('GET', cr.req.uri);
+
+		if (!handlers.length) return null;
+
+		cr.req.setContext('params', params);
+
+		for (const handler of handlers) {
+			const res = await handler(cr);
+			if (res) return res;
+		}
+
+		return null;
+	}
+}
+
+export function getEntryParam(cr: CrelteRequest, key: string): string | null {
+	return (cr.req.getContext('params') ?? {})[key] ?? null;
+}

--- a/packages/core/src/routing/EntryRouter.ts
+++ b/packages/core/src/routing/EntryRouter.ts
@@ -1,11 +1,14 @@
 import { Pattern, Trouter } from 'trouter';
-import { CrelteRequest, Entry } from '../index.js';
+import { Crelte, CrelteRequest, Entry } from '../index.js';
 
 export type EntryRouteHandler = (
 	cr: CrelteRequest,
 ) => Promise<Entry | null | undefined> | Entry | null | undefined;
 
-export type EntryRoutes = (router: EntryRouter) => Promise<void> | void;
+export type EntryRoutes = (
+	crelte: Crelte,
+	router: EntryRouter,
+) => Promise<void> | void;
 
 export default class EntryRouter {
 	private inner: Trouter<EntryRouteHandler>;

--- a/packages/core/src/routing/index.ts
+++ b/packages/core/src/routing/index.ts
@@ -2,6 +2,11 @@ import Router from './Router.js';
 import Route, { type RouteOptions } from './Route.js';
 import Request, { type RequestOptions, type DelayRender } from './Request.js';
 import Site from './Site.js';
+import EntryRouter, {
+	getEntryParam,
+	type EntryRoutes,
+	type EntryRouteHandler,
+} from './EntryRouter.js';
 
 export {
 	Router,
@@ -11,4 +16,8 @@ export {
 	Request,
 	DelayRender,
 	RequestOptions,
+	EntryRouter,
+	getEntryParam,
+	EntryRoutes,
+	EntryRouteHandler,
 };


### PR DESCRIPTION
Closes #64 

This adds the following to the public api:
`import('crelte').Entry`
`import('crelte/routing').{EntryRouter, getEntryParam, EntryRoutes, EntryRouteHandler}`

In the App `module="context"` you can add the following
```ts
import { Crelte, CrelteRequest } from 'crelte';
import { EntryRouter, getEntryParam } from 'crelte/routing';

export function entryRoutes(crelte: Crelte, router: EntryRouter) {
    router.add('/news/:id', (cr: CrelteRequest) => {
        const id = getEntryParam(cr, 'id');

        return {
            sectionHandle: 'custom',
            typeHandle: 'type'
        }
    });
}
```